### PR TITLE
Add an HTML diagram builder tool for agent networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,21 +8,31 @@ A web client for agent-networks built using the Neuro AI agent framework (neuro-
 pip install -r requirements.txt
 ```
 
-## Usage
+## Generate an HTML agent network diagram
+Generate an HTML diagram of agents based on a .hocon file containing an agent network configuration:
+
+```bash
+python -m utils.agents_diagram_builder --input_file <path_to_hocon_file> --output_file <path_to_output_file>
+````
+
+For example, for a `onec_assistant.hocon` file:
+```bash
+python -m utils.agents_diagram_builder --input_file /Users/754337/workspace/neuro-san-1c/registries/onec_assistant.hocon --output_file ./web_client/static/onec_assistant.html
+````
+
+## Start the web client
 Start the application with:
 ```bash
-python ./web_client/app.py
+python -m web_client.app
 ```
 Then go to http://127.0.0.1:5432 in your browser.
 
-In the Configuration tab, choose an Agent Network Name, e.g. "intranet_agents".
+In the Configuration tab, choose an Agent Network Name, e.g. "onec_assistant".
 This agent network name should match
-- the name of the `.html` file in the `web_client/static` directory
-- the name of the `.hocon` file
-in the `backend/agents/registries` directory of the `unileaf repo.
-Then click "update" button to update the Agent Network Diagram.
+- the name of a `.html` file in the `web_client/static` directory
+- the name of the `.hocon` file used when starting the `neuro-san` server. 
+Then click the "update" button to update the Agent Network Diagram.
 
-The .html file must match the .hocon file network. If not, regenerate the .html file.
-See https://github.com/leaf-ai/agents_diagram_builder for how to do it.
+The .html file must match the .hocon file network used by the `neuro-san` server.
 
 You can now type your message in the chat box and press 'Send' to interact with the agent network.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,14 +7,11 @@ git+https://${LEAF_SOURCE_CREDENTIALS}@github.com/leaf-ai/neuro-san.git@0.1.14
 Flask==3.0.3
 Flask-SocketIO==5.4.1
 
-# These are needed for generating code from .proto files
-grpcio==1.62.0
-grpcio-health-checking==1.62.0
-grpcio-reflection==1.62.0
-grpcio-tools==1.62.0
-
 pyOpenSSL==24.0.0
 PyJWT>=2.9.0
 hvac==1.1.0
 
 eventlet==0.33.3  # or the latest version
+
+# For the HTML diagram builder tool
+pyvis~=0.3.2

--- a/utils/agents_diagram_builder.py
+++ b/utils/agents_diagram_builder.py
@@ -1,0 +1,167 @@
+import argparse
+
+from pyhocon import ConfigFactory
+from pyvis.network import Network
+
+
+class DiagramBuilder:
+    """
+    Builds a .html file containing an interactive agent network diagram
+    from a .hocon file containing agent definitions and connections.
+    """
+    def __init__(self):
+        self.args = None
+
+    @staticmethod
+    def parse_agent_definitions(agent_data):
+        agent_graph = {}
+
+        # Step 1: First pass to gather all agents and their details
+        tools = agent_data.get("tools", [])
+        for tool in tools:
+            agent_name = tool.get("name", "unknown_agent")
+            agent_info = {
+                "instructions": tool.get("instructions", "No instructions"),
+                "command": tool.get("command", "No command"),
+                "class": tool.get("class", "No class")
+            }
+            agent_graph[agent_name] = {"info": agent_info, "connections": tool.get("tools", [])}
+
+        return agent_graph
+
+    @staticmethod
+    def create_interactive_agent_graph(agent_graph, output_html):
+        # Initialize a pyvis network graph
+        net = Network(height="750px", width="100%", bgcolor="#222222", font_color="white", directed=True)
+
+        # Step 2: First add all nodes to the pyvis network
+        for agent_name, agent_data in agent_graph.items():
+            # Add node with hover information
+            hover_text = f"Instructions: {agent_data['info']['instructions']}<br>"
+            hover_text += f"Class: {agent_data['info']['class']}<br>"
+            hover_text += f"Command: {agent_data['info']['command']}<br>"
+
+            net.add_node(agent_name, title=hover_text, label=agent_name)
+
+        # Step 3: Then add all edges (connections between agents)
+        for agent_name, agent_data in agent_graph.items():
+            connections = agent_data["connections"]
+            for connection in connections:
+                if connection in agent_graph:
+                    net.add_edge(agent_name, connection)
+                else:
+                    print(f"Warning: {connection} referenced by {agent_name} does not exist.")
+
+        # Disable hierarchical layout and physics for free node movement
+        net.set_options("""
+         {
+           "physics": {
+             "enabled": false
+           },
+           "interaction": {
+             "zoomView": false,
+             "dragView": true
+           },
+           "manipulation": {
+             "enabled": false
+           },
+           "autoResize": true
+         }
+         """)
+
+        # Save the interactive network to an HTML file
+        net.save_graph(output_html)
+
+        # Inject CSS to center the graph when used in an iframe
+        with open(output_html, 'r') as file:
+            html_content = file.read()
+
+        # Center the graph by adding custom styles
+        centered_style = """
+            <style>
+              #mynetwork {
+                  width: 100%;
+                  background-color: #222222;
+                  border: 1px solid lightgray;
+                  position: relative;
+              }
+            
+              body, html {
+                  margin: 0;
+                  padding: 0;
+                  overflow: hidden;  /* Prevent scrollbars in the iframe */
+                  width: 100%;
+                  height: 100%;
+              }
+            
+              .vis-network {
+                  display: flex;
+                  justify-content: center;  /* Center horizontally */
+                  align-items: center;      /* Center vertically */
+              }
+            </style>
+        """
+        custom_script = """
+    <script type="text/javascript">
+        window.addEventListener('message', function(event) {
+            if (event.data && event.data.agentName) {
+                const agentName = event.data.agentName;
+    
+                // Directly compare the lowercase agent name with the node ID
+                const matchingNode = nodes.get().find(node => node.id.toLowerCase() === agentName);
+    
+                if (matchingNode) {
+                    // Reset the color of all nodes to default
+                    nodes.forEach(function(node) {
+                        nodes.update({ id: node.id, color: '#97c2fc' });
+                    });
+    
+                    // Highlight the matched node
+                    nodes.update({ id: matchingNode.id, color: '#ff6347' });
+                }
+            }
+        });
+    </script>
+        """
+
+        # Inject the custom style to center the graph in the iframe
+        html_content = html_content.replace("</head>", f"{centered_style}</head>")
+        html_content = html_content.replace("</body>", f"{custom_script}</body>")
+
+        # Write the modified content back to the HTML file
+        with open(output_html, 'w') as file:
+            file.write(html_content)
+
+    def create_agent_diagram_from_hocon(self, hocon_file, output_html="agent_network.html"):
+        # Load the HOCON configuration
+        agent_data = ConfigFactory.parse_file(hocon_file)
+
+        # Parse the agents and tools from the HOCON data
+        agent_graph = self.parse_agent_definitions(agent_data)
+
+        # Create an interactive agent graph and save it as a web page
+        self.create_interactive_agent_graph(agent_graph, output_html)
+
+    def parse_args(self):
+        """
+        Parse command line arguments into member variables
+        """
+        arg_parser = argparse.ArgumentParser(
+            description="Builds a .html file containing an interactive agent network diagram "
+                        "from a .hocon file containing agent definitions and connections."
+        )
+        arg_parser.add_argument("-i", "--input_file", type=str, default=None, required=True,
+                                help="Path to the input .hocon file containing the agent network definition")
+        arg_parser.add_argument("-o", "--output_file", type=str, default=None, required=True,
+                                help="Path to the file to generate: an .html file containing the interactive"
+                                     " agent network diagram")
+        self.args = arg_parser.parse_args()
+
+    def main(self):
+        self.parse_args()
+        self.create_agent_diagram_from_hocon(hocon_file=self.args.input_file,
+                                             output_html=self.args.output_file)
+
+
+if __name__ == '__main__':
+    DiagramBuilder().main()


### PR DESCRIPTION
Moved the diagram builder tool from https://github.com/leaf-ai/agents_diagram_builder into a `utils/` folder here.
This repo is the only place where the diagram builder tool is used, and that's where we need it.

Updated the README.md with instructions about how to use it.