### PR TITLE
Manage sly_data in the session's state

### DIFF
--- a/requirements-private.txt
+++ b/requirements-private.txt
@@ -1,4 +1,4 @@
 # Private repos: Neuro SAN and its dependencies
 git+https://${LEAF_SOURCE_CREDENTIALS}@github.com/leaf-ai/leaf-common.git@1.2.20
 git+https://${LEAF_PRIVATE_SOURCE_CREDENTIALS}@github.com/leaf-ai/leaf-server-common.git@0.1.17
-git+https://${LEAF_SOURCE_CREDENTIALS}@github.com/leaf-ai/neuro-san.git@0.5.8
+git+https://${LEAF_SOURCE_CREDENTIALS}@github.com/leaf-ai/neuro-san.git@0.5.10


### PR DESCRIPTION
We now update the state's `sly_data` with any sly data returned by the agent.
If the agent returned a session ID and a token for instance, we keep them in the state to pass them down for the next call to the agent.