### PR TITLE
Correct bad syntax in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 # This license name comes from doc recommendation here
 # https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license
 license = "LicenseRef-CognizantAcademicSource"
-license = {file = "LICENSE.txt"}
+license-files = ["LICENSE.txt"]
 requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
This PR fixes bad syntax in the project file.

I can follow up later and add some minimal test to at least be sure the dist will build. 