### PR TITLE
Move neuro-san dependency to 5.19 for CORS fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # In-house dependencies
 leaf_common==1.2.21
 leaf_server_common==0.1.18
-neuro_san==0.5.15
+neuro_san==0.5.19
 
 # Flask
 Flask==3.1.0


### PR DESCRIPTION
Take the latest neuro-san which contains fix for CORS issue.