### PR TITLE
Remove unnecessary requirements because they come with neuro-san

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
 # In-house dependencies
-leaf_common==1.2.21
-leaf_server_common==0.1.18
 neuro_san==0.5.20
 
 # Flask


### PR DESCRIPTION
`leaf-common` and `leaf-server-common` come with `neuro-san` from pypi now. No need to specify them anymore.